### PR TITLE
fix pch path

### DIFF
--- a/CEncrypt.c
+++ b/CEncrypt.c
@@ -55,7 +55,7 @@ int touufrombits(unsigned char *out, const unsigned char *in, long inlen)
     int len;
     
     if (inlen > 45) return -1;
-    len = (inlen * 4 + 2) / 3 + 1;
+    len = (int)(inlen * 4 + 2) / 3 + 1;
     *out++ = uudigit[inlen];
     
     for (; inlen >= 3; inlen -= 3) {

--- a/Encrypt.xcodeproj/project.pbxproj
+++ b/Encrypt.xcodeproj/project.pbxproj
@@ -213,7 +213,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "/Users/dan/Dropbox/Coding/Encrypt/DFSimpleEncrypt/Encrypt-Prefix.pch";
+				GCC_PREFIX_HEADER = "DFSimpleEncrypt/Encrypt-Prefix.pch";
 				GCC_VERSION = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -223,7 +223,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "/Users/dan/Dropbox/Coding/Encrypt/DFSimpleEncrypt/Encrypt-Prefix.pch";
+				GCC_PREFIX_HEADER = "DFSimpleEncrypt/Encrypt-Prefix.pch";
 				GCC_VERSION = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};


### PR DESCRIPTION
The pch file path in the project should point to the pch file built into the project, not in DropBox; also got rid of a compiler warning.

My guess is that you never got a bug or mention of this before because it is a relatively easy fix.  

Thanks for making this project available!
